### PR TITLE
[stats] Fix visibility of StatsReader from package default to public

### DIFF
--- a/stats/src/main/java/com/facebook/stats/mx/StatsReader.java
+++ b/stats/src/main/java/com/facebook/stats/mx/StatsReader.java
@@ -23,7 +23,7 @@ import com.facebook.stats.MultiWindowDistribution;
 import com.facebook.stats.MultiWindowRate;
 import com.facebook.stats.MultiWindowSpread;
 
-interface StatsReader {
+public interface StatsReader {
   void exportCounters(Map<String, Long> counters);
   MultiWindowRate getRate(String key);
   MultiWindowRate getRate(StatType statType);


### PR DESCRIPTION
StatsReader interface has package default visibility. Looks like it was a recent change where it was changed from public to package default. I am changing it back to public to un-break puma.